### PR TITLE
Drop Node.js 6 support

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,4 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
-const nodeMajorVersion = +process.versions.node.split('.')[0];
-module.exports = nodeMajorVersion >= 7 ?
-  require('./dist/src') :
-  require('./dist6/src');
+module.exports = require('./dist');

--- a/package.json
+++ b/package.json
@@ -7,14 +7,11 @@
     "graphql"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "scripts": {
-    "acceptance": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/acceptance/**/*.js'",
-    "build": "npm run build:dist && npm run build:dist6",
-    "build:current": "lb-tsc",
-    "build:dist": "lb-tsc es2017",
-    "build:dist6": "lb-tsc es2015",
+    "acceptance": "lb-mocha \"DIST/test/acceptance/**/*.js\"",
+    "build": "lb-tsc es2017",
     "build:apidocs": "lb-apidocs",
     "lint": "npm run prettier:check && npm run tslint",
     "lint:fix": "npm run prettier:fix && npm run tslint:fix",
@@ -25,29 +22,28 @@
     "prettier:fix": "npm run prettier:cli -- --write",
     "clean": "lb-clean loopback-graphql*.tgz dist*",
     "prepare": "npm run build && npm run build:apidocs",
-    "pretest": "npm run build:current",
-    "integration": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/integration/**/*.js'",
-    "test": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/unit/**/*.js' 'DIST/test/integration/**/*.js' 'DIST/test/acceptance/**/*.js'",
-    "unit": "lb-dist mocha --opts ../../test/mocha.opts 'DIST/test/unit/**/*.js'",
+    "pretest": "npm run build",
+    "integration": "lb-mocha \"DIST/test/integration/**/*.js\"",
+    "test": "lb-mocha \"DIST/test/unit/**/*.js\" \"DIST/test/integration/**/*.js\" \"DIST/test/acceptance/**/*.js\"",
+    "unit": "lb-mocha \"DIST/test/unit/**/*.js\"",
     "verify": "npm pack && tar xf loopback-graphql*.tgz && tree package && npm run clean"
   },
   "author": "IBM",
   "license": "MIT",
   "dependencies": {
-    "@loopback/context": "^4.0.0-alpha.14",
-    "@loopback/core": "^4.0.0-alpha.16",
+    "@loopback/context": "^4.0.0-alpha.30",
+    "@loopback/core": "^4.0.0-alpha.32",
     "graphql": "^0.11.7"
   },
   "devDependencies": {
-    "@loopback/build": "^4.0.0-alpha.3",
-    "@loopback/testlab": "^4.0.0-alpha.9"
+    "@loopback/build": "^4.0.0-alpha.13",
+    "@loopback/testlab": "^4.0.0-alpha.23"
   },
   "files": [
     "README.md",
     "index.js",
     "index.d.ts",
     "dist/src",
-    "dist6/src",
     "api-docs"
   ],
   "repository": {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,2 @@
+--recursive
+--reporter dot

--- a/test/unit/dummy-test.ts
+++ b/test/unit/dummy-test.ts
@@ -1,0 +1,9 @@
+import {expect} from '@loopback/testlab';
+
+// this file is just a placeholder to make CI pass.
+// it can be removed once real tests are made.
+describe('dummy test - remove me later', () => {
+  it('works', () => {
+    expect(1).to.equal(1);
+  });
+});


### PR DESCRIPTION
LoopBack4 is dropping support for Node 6 because it is no longer LTS and doesn't support newer features. It's best for extensions to align with it.

BREAKING CHANGE: Support for Node.js version lower than 8.0 has been dropped. Please upgrade to Node 8 or higher.
Connect to https://github.com/strongloop/loopback-next/issues/611